### PR TITLE
Call to build.getEnvironment() should not use null as parameter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/valgrind/ValgrindPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/valgrind/ValgrindPublisher.java
@@ -104,7 +104,7 @@ public class ValgrindPublisher extends Recorder
 			return false;
 		}
 		
-		EnvVars env = build.getEnvironment(null);
+		EnvVars env = build.getEnvironment();
 
 		ValgrindLogger.log(listener, "Analysing valgrind results");		
 


### PR DESCRIPTION
Call to build.getEnvironment() should not use null as parameter. This method will attempt to auto-install a JDK if required in order to obtain env vars. At some point, a message tries to be logged and a NPE occurs.

ERROR: Publisher org.jenkinsci.plugins.valgrind.ValgrindPublisher aborted due to exception
java.lang.NullPointerException
    at hudson.tools.JDKInstaller.performInstallation(JDKInstaller.java:110)
    at hudson.tools.InstallerTranslator.getToolHome(InstallerTranslator.java:61)
    at hudson.tools.ToolLocationNodeProperty.getToolHome(ToolLocationNodeProperty.java:107)
    at hudson.tools.ToolInstallation.translateFor(ToolInstallation.java:203)
    at hudson.model.JDK.forNode(JDK.java:122)
    at hudson.model.AbstractProject.getEnvironment(AbstractProject.java:341)
    at hudson.model.Run.getEnvironment(Run.java:2040)
    at hudson.model.AbstractBuild.getEnvironment(AbstractBuild.java:933)
    at org.jenkinsci.plugins.valgrind.ValgrindPublisher.perform(ValgrindPublisher.java:107)
    at hudson.tasks.BuildStepMonitor$3.perform(BuildStepMonitor.java:36)
    at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:804)
    at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:776)
