### PR TITLE
FIXED JENKINS-16859 Plugin forgets 'Ignore Exit Code' setting

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/valgrind/ValgrindBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/valgrind/ValgrindBuilder.java
@@ -254,6 +254,11 @@ public class ValgrindBuilder extends Builder
 	{
 		return showReachable;
 	}
+        
+        public boolean isIgnoreExitCode()
+        {
+                return ignoreExitCode;
+        }
 
 	public boolean isUndefinedValueErrors()
 	{


### PR DESCRIPTION
I think this resolve the JIRA JENKINS-16859 issue
