### PR TITLE
[FIXED JENKINS-23220]: Make Valgrind publisher available on all types of projects

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/valgrind/ValgrindPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/valgrind/ValgrindPublisher.java
@@ -254,8 +254,7 @@ public class ValgrindPublisher extends Recorder
 		@Override
 		public boolean isApplicable(Class<? extends AbstractProject> jobType)
 		{
-			return FreeStyleProject.class.isAssignableFrom(jobType)
-					|| MatrixProject.class.isAssignableFrom(jobType);
+			return true;
 		}
 
 		@Override


### PR DESCRIPTION
I don't know the reason why "Publish valgrind results" was disabled for project types other than free form and matrix but this seems to be too restrictive. I am using publish valgrind results on a project with inheritance plugin and looks all right. 