### PR TITLE
Add environment to child process

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/valgrind/call/ValgrindCall.java
+++ b/src/main/java/org/jenkinsci/plugins/valgrind/call/ValgrindCall.java
@@ -129,6 +129,7 @@ public class ValgrindCall
 		starter = starter.stdout(stdout);
 		starter = starter.stderr(stderr);
 		starter = starter.cmds(cmds);
+		starter = starter.envs(env);
 
 		return starter.join();
 	}


### PR DESCRIPTION
Sometimes it is necessary to pass additional environment variables
to child process like LD_LIBRARY_PATH or QT_PLUGIN_PATH to run
the binaries.