### PR TITLE
Fix layout of trend graph

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/valgrind/graph/ValgrindGraph.java
+++ b/src/main/java/org/jenkinsci/plugins/valgrind/graph/ValgrindGraph.java
@@ -28,7 +28,7 @@ public class ValgrindGraph extends Graph
 	private final CategoryDataset categoryDataset;
 
 	public static final int DEFAULT_CHART_WIDTH = 500;
-	public static final int DEFAULT_CHART_HEIGHT = 200;
+	public static final int DEFAULT_CHART_HEIGHT = 250;
 
 	public ValgrindGraph(AbstractBuild<?, ?> owner, CategoryDataset categoryDataset, String yLabel,
 			int chartWidth, int chartHeight)


### PR DESCRIPTION
After adding the Helgrind error kinds to the trend graph, the legend required 2 columns and hid parts of the graph. This fixes the issue by simply increasing the graph height.