### PR TITLE
[[JENKINS-35003]: Add ability to substitute source paths.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/valgrind/config/ValgrindPublisherConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/valgrind/config/ValgrindPublisherConfig.java
@@ -15,10 +15,12 @@ public class ValgrindPublisherConfig implements Serializable
 	private String unstableThresholdInvalidReadWrite;
 	private String unstableThresholdDefinitelyLost;
 	private String unstableThresholdTotal;	
+	private String sourceSubstitutionPaths;
 	private boolean publishResultsForAbortedBuilds;
 	private boolean publishResultsForFailedBuilds;
 	private boolean failBuildOnMissingReports;
 	private boolean failBuildOnInvalidReports;
+
 	
 	@DataBoundConstructor
 	public ValgrindPublisherConfig( String pattern, 
@@ -28,6 +30,7 @@ public class ValgrindPublisherConfig implements Serializable
 			String unstableThresholdInvalidReadWrite, 
 			String unstableThresholdDefinitelyLost, 
 			String unstableThresholdTotal,
+			String sourceSubstitutionPaths,
 			boolean publishResultsForAbortedBuilds,
 			boolean publishResultsForFailedBuilds,
 			boolean failBuildOnMissingReports,
@@ -39,7 +42,8 @@ public class ValgrindPublisherConfig implements Serializable
 		this.failThresholdTotal = failThresholdTotal.trim();		
 		this.unstableThresholdInvalidReadWrite = unstableThresholdInvalidReadWrite.trim();
 		this.unstableThresholdDefinitelyLost = unstableThresholdDefinitelyLost.trim();
-		this.unstableThresholdTotal = unstableThresholdTotal.trim();	
+		this.unstableThresholdTotal = unstableThresholdTotal.trim();
+		this.sourceSubstitutionPaths = sourceSubstitutionPaths.trim();
 		this.publishResultsForAbortedBuilds = publishResultsForAbortedBuilds;
 		this.publishResultsForFailedBuilds = publishResultsForFailedBuilds;
 		this.failBuildOnMissingReports = failBuildOnMissingReports;
@@ -85,6 +89,10 @@ public class ValgrindPublisherConfig implements Serializable
 		return unstableThresholdTotal;
 	}
 
+	public String  getSourceSubstitutionPaths(){
+		return sourceSubstitutionPaths;
+	}
+	
 	public boolean isPublishResultsForAbortedBuilds()
 	{
 		return publishResultsForAbortedBuilds;

--- a/src/main/java/org/jenkinsci/plugins/valgrind/util/ValgrindSourceGrabber.java
+++ b/src/main/java/org/jenkinsci/plugins/valgrind/util/ValgrindSourceGrabber.java
@@ -24,13 +24,18 @@ public class ValgrindSourceGrabber
 	private File destDirectory;
 	private FilePath basedir;
 	private int index = 0;
+	private final ValgrindSourceResolver sourceResolver;
 	
 	public ValgrindSourceGrabber(BuildListener listener, FilePath basedir)
 	{
+		this(listener, basedir, new ValgrindSourceResolver());
+	}
+	public ValgrindSourceGrabber(BuildListener listener, FilePath basedir, ValgrindSourceResolver sourceResolver)
+	{
 		this.listener = listener;
 		this.basedir = basedir;	
+		this.sourceResolver = sourceResolver;
 	}
-	
 	public boolean init(File localRoot)
 	{
         this.destDirectory = new File(localRoot, ValgrindSourceFile.SOURCE_DIRECTORY);
@@ -57,19 +62,24 @@ public class ValgrindSourceGrabber
 			if ( frame == null )
 				continue;
 			
-			String filePath =  frame.getFilePath();
 			
+			String filePath = frame.getFilePath();
+					
 			if ( filePath == null || filePath.isEmpty() || lookup.containsKey( filePath ) )
-				continue;				
+				continue;
 			
-			FilePath file = new FilePath( basedir, filePath );
+			String resolvedFilePath =  sourceResolver.resolveFilePath(filePath);
+			if (resolvedFilePath == null || resolvedFilePath.isEmpty()){
+				continue;
+			}
+			FilePath file = new FilePath( basedir, resolvedFilePath );
 			
 			index++;				
 			lookup.put( filePath, retrieveSourceFile( file ) );
 		}
 	}
-	
-	public Map<String, String> getLookupMap()
+
+    public Map<String, String> getLookupMap()
 	{
 		return lookup;
 	}

--- a/src/main/java/org/jenkinsci/plugins/valgrind/util/ValgrindSourceResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/valgrind/util/ValgrindSourceResolver.java
@@ -1,0 +1,65 @@
+package org.jenkinsci.plugins.valgrind.util;
+
+import java.util.AbstractMap.SimpleEntry;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.logging.Logger;
+
+public class ValgrindSourceResolver {
+
+	private static Logger logger = Logger.getLogger(ValgrindSourceResolver.class.getName());
+	
+	protected final List<SimpleEntry<String, String>> substitutionPathList = new ArrayList<SimpleEntry<String, String>>();
+
+	public ValgrindSourceResolver() {
+	}
+	public ValgrindSourceResolver(String sourcePathSubstitutions) {
+		parseSubstitutions(sourcePathSubstitutions);
+	}
+
+	public String resolveFilePath(String filePath) {
+		if (filePath == null) return null;
+		for (SimpleEntry<String,String> substitute: substitutionPathList){
+			if (filePath.startsWith(substitute.getKey())){
+				return filePath.replaceFirst(substitute.getKey(), substitute.getValue());
+			}
+		}
+		return filePath;
+	}
+	private void parseSubstitutions(String sourcePathSubstitutions) {
+		if (sourcePathSubstitutions != null) {
+			String[] sourcePathSubstitutionArray = sourcePathSubstitutions
+					.split(",");
+			if (sourcePathSubstitutionArray != null) {
+				for (String sourcePathSubstitution : sourcePathSubstitutionArray) {
+					String[] sourcePathsPair = sourcePathSubstitution.trim()
+							.split(":");
+					if (sourcePathsPair.length != 2) {
+						logger.warning(String.format("Source path substitution %s is incorrect", sourcePathSubstitution));
+					} else {
+						SimpleEntry<String, String> sourcePathSubstitutionKVP = new SimpleEntry<String, String>(
+								sourcePathsPair[0].trim(),
+								sourcePathsPair[1].trim());
+						logger.fine(
+								String.format("Adding source path substitution %s:%s", 
+										sourcePathSubstitutionKVP.getKey(), sourcePathSubstitutionKVP.getValue()));
+						substitutionPathList
+								.add(sourcePathSubstitutionKVP);
+					}
+				}
+			}
+		}
+
+		Comparator<SimpleEntry<String, String>> longestFirstComparator = new Comparator<SimpleEntry<String, String>>() {
+			public int compare(SimpleEntry<String, String> o1, SimpleEntry<String, String> o2) {
+				return Integer.compare(o2.getKey().length(),o1.getKey().length());
+			}
+			
+		};
+		Collections.sort(substitutionPathList, longestFirstComparator);
+	}
+}

--- a/src/main/resources/org/jenkinsci/plugins/valgrind/ValgrindPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/valgrind/ValgrindPublisher/config.jelly
@@ -8,6 +8,12 @@
         <f:textbox name="valgrind.pattern" value="${instance.valgrindPublisherConfig.pattern}"/>
     </f:entry>
     
+    <f:entry title="Source substitution paths:" 
+        description="Mappings to substitute source paths. e.g.: /home/source1:/home/destination1,/home/source2:/home/destination2">
+        
+        <f:textbox name="valgrind.sourceSubstitutionPaths" value="${instance.valgrindPublisherConfig.sourceSubstitutionPaths}"/>
+    </f:entry>
+    
 	  <f:entry title="Fail build on missing reports" description="Mark build as failed if no report was found.">
 		<f:checkbox name="valgrind.failBuildOnMissingReports" checked="${instance.valgrindPublisherConfig.failBuildOnMissingReports}"/>
 	  </f:entry>     

--- a/src/test/java/org/jenkinsci/plugins/valgrind/util/ValgrindSourceResolverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/valgrind/util/ValgrindSourceResolverTest.java
@@ -1,0 +1,49 @@
+package org.jenkinsci.plugins.valgrind.util;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ValgrindSourceResolverTest {
+	String singleSubstitutionPathList = "/home/jenkins:/home/makeuser";
+	String substitutionPathList = "/home/jenkins:/home/makeuser,/home/jenkins/workspace:/home/root/workspace";
+    @Test
+    public void testValgrindSourceResolverSortsSubstitutionPathList(){
+    	ValgrindSourceResolver sourceResolver = new ValgrindSourceResolver(substitutionPathList);
+    	List<SimpleEntry<String,String>> expectedSubstitutionPathList = new ArrayList<SimpleEntry<String, String>>(2);
+    	expectedSubstitutionPathList.add(new SimpleEntry<String,String>("/home/jenkins/workspace","/home/root/workspace"));
+    	expectedSubstitutionPathList.add(new SimpleEntry<String,String>("/home/jenkins","/home/makeuser"));
+    	Assert.assertEquals("Expected substitution path list does not match actual",expectedSubstitutionPathList, sourceResolver.substitutionPathList);
+    }
+    @Test
+    public void testValgrindSourceResolverParsesSingleSubstitutionPath(){
+    	ValgrindSourceResolver sourceResolver = new ValgrindSourceResolver(singleSubstitutionPathList);
+    	List<SimpleEntry<String,String>> expectedSubstitutionPathList = new ArrayList<SimpleEntry<String, String>>();
+    	expectedSubstitutionPathList.add(new SimpleEntry<String,String>("/home/jenkins","/home/makeuser"));
+    	Assert.assertEquals("Expected substitution path list does not match actual",expectedSubstitutionPathList, sourceResolver.substitutionPathList);
+    }
+    @Test
+    public void testValgrindSourceResolverResolvesFileFromLongerSubstitutionPath(){
+    	ValgrindSourceResolver sourceResolver = new ValgrindSourceResolver(substitutionPathList);
+    	String expectedResolvedFilePath = "/home/root/workspace/file.cpp";
+    	String resolvedSourceFilePath = sourceResolver.resolveFilePath("/home/jenkins/workspace/file.cpp");
+    	Assert.assertEquals("Resolved file does not match expected",expectedResolvedFilePath, resolvedSourceFilePath);
+    }
+    @Test
+    public void testValgrindSourceResolverResolvesFileFromSubstitutionPath(){
+    	ValgrindSourceResolver sourceResolver = new ValgrindSourceResolver(substitutionPathList);
+    	String expectedResolvedFilePath = "/home/makeuser/file.cpp";
+    	String resolvedSourceFilePath = sourceResolver.resolveFilePath("/home/jenkins/file.cpp");
+    	Assert.assertEquals("Resolved file does not match expected",expectedResolvedFilePath, resolvedSourceFilePath);
+    }
+    @Test
+    public void testValgrindSourceResolverResolvesFileReturningOriginalFileWhenNoSubsitionPathMatches(){
+    	ValgrindSourceResolver sourceResolver = new ValgrindSourceResolver(substitutionPathList);
+    	String expectedResolvedFilePath = "/home/root/file.cpp";
+    	String resolvedSourceFilePath = sourceResolver.resolveFilePath(expectedResolvedFilePath);
+    	Assert.assertEquals("Resolved file does not match expected",expectedResolvedFilePath, resolvedSourceFilePath);
+    }
+}


### PR DESCRIPTION
Somethimes you do not want to build a program and execute lengthy valgrind/memcheck/hellgrind examination from within the same JENKINS job.
When workspace where a program is run under valgrind is different from the workspace where program was built the vagrant plugin will not be able to find sources.
In gdb this problem is solved using set-substitute-path. In valgring JENKINS plugin it is proposed that a source mappings are added.
Here is the link to gdb command documentation: 
https://sourceware.org/gdb/onlinedocs/gdb/Source-Path.html#set%20substitute%2dpath
