### PR TITLE
avoid problems with short args

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/valgrind/model/ValgrindProcess.java
+++ b/src/main/java/org/jenkinsci/plugins/valgrind/model/ValgrindProcess.java
@@ -86,7 +86,7 @@ public class ValgrindProcess implements Serializable
 		valgrind_arguments.add(arg);
 		
 		// actually, we only really care about the tool argument
-		if ( arg.substring(0, 7).equals("--tool=")) {
+		if ( arg.startsWith("--tool=") ) {
 			tool = arg.substring(7);
 		}
 	}

--- a/src/test/resources/org/jenkinsci/plugins/valgrind/parser/simple.xml
+++ b/src/test/resources/org/jenkinsci/plugins/valgrind/parser/simple.xml
@@ -19,6 +19,7 @@
 <args>
   <vargv>
     <exe>/usr/bin/valgrind.bin</exe>
+    <arg>-v</arg>
     <arg>--suppressions=/usr/lib/valgrind/debian-libc6-dbg.supp</arg>
     <arg>--tool=memcheck</arg>
     <arg>--track-origins=no</arg>


### PR DESCRIPTION
Fix JENKINS-35422 issue that occurs when valgrind is called with short command line arguments.
