### PR TITLE
fix for not calling executables under unix

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/valgrind/call/ValgrindCall.java
+++ b/src/main/java/org/jenkinsci/plugins/valgrind/call/ValgrindCall.java
@@ -117,6 +117,10 @@ public class ValgrindCall
 		for (String option : customValgindOptions)
 			cmds.add(env.expand(option));
 
+		if (!System.getProperty("os.name").startsWith("Windows")) {
+			programName = "." + programName;
+		}
+		
 		cmds.add(programName);
 
 		for (String argument : programArguments)


### PR DESCRIPTION
As it seems to be impossible to create issues I added this pullrequest. My initial problem was that executables on Linux do not get called properly by the plugin using Jenkins pipelines. The dot in front of the call is missing and results in error code 127.