### PR TITLE
Propagate owner from buildActions to result when necessary

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/valgrind/ValgrindBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/valgrind/ValgrindBuildAction.java
@@ -122,6 +122,13 @@ public class ValgrindBuildAction extends AbstractValgrindBuildAction implements 
 		{
 			final Run<?,?> run = buildAction.owner;
 			final ChartUtil.NumberOnlyBuildLabel label = new ChartUtil.NumberOnlyBuildLabel(run);
+			
+			if (buildAction.getResult().getOwner() == null)
+			{
+			    // Result owner is null. Propagate our owner to the result.
+			    buildAction.getResult().setOwner(run);
+			}
+			
 			final ValgrindReport report = buildAction.getResult().getReport();
 
 			// Memcheck:

--- a/src/main/java/org/jenkinsci/plugins/valgrind/ValgrindResult.java
+++ b/src/main/java/org/jenkinsci/plugins/valgrind/ValgrindResult.java
@@ -136,4 +136,9 @@ public class ValgrindResult implements Serializable
 		}
 	}
 
+    public void setOwner(Run<?, ?> owner)
+    {
+        this.owner = owner;
+    }
+
 }


### PR DESCRIPTION
This is related to the issue reported here: https://issues.jenkins-ci.org/browse/JENKINS-50558

There is probably a more root-cause fix that could be made (I don't know where these ValgrindResult instances come from exactly), but this fixes them up after the fact.  It seems that at some point (restarting Jenkins is one trigger), these ValgrindResult objects no longer have an "owner".  This repopulates them when necessary before generating the results.