### PR TITLE
Do not wait for checkpoint from previous build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/valgrind/ValgrindPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/valgrind/ValgrindPublisher.java
@@ -82,7 +82,7 @@ public class ValgrindPublisher extends Recorder implements SimpleBuildStep
 	@Override
 	public BuildStepMonitor getRequiredMonitorService()
 	{
-		return BuildStepMonitor.BUILD;
+		return BuildStepMonitor.NONE;
 	}
 
 	protected boolean canContinue(final Result result)


### PR DESCRIPTION
Fixes an issue with result archiver getting stuck for a long time in concurrent builds.
A similar issue has been fixed in the JUnit Jenkins plugin:

https://issues.jenkins-ci.org/browse/JENKINS-10234
jenkinsci/jenkins@90ff9f8