### PR TITLE
Fix XXE and XSS vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
             <scope>test</scope>
         </dependency>
 
+	<dependency>
+		<groupId>org.apache.commons</groupId>
+		<artifactId>commons-text</artifactId>
+		<version>1.3</version>
+	</dependency>
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <version>0.29-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Jenkins Valgrind Plug-in</name>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Valgrind+Plugin</url>
+    <url>https://wiki.jenkins-ci.org/display/JENKINS/Valgrind+Plugin</url>
 
     <licenses>
         <license>
@@ -37,14 +37,14 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/src/main/java/org/jenkinsci/plugins/valgrind/ValgrindResult.java
+++ b/src/main/java/org/jenkinsci/plugins/valgrind/ValgrindResult.java
@@ -85,7 +85,7 @@ public class ValgrindResult implements Serializable
 
 	/**
 	 *
-	 * @param link expected to be in format "id=<executable name>,<unique error id>"
+	 * @param link expected to be in format "id=&lt;executable name&gt;,&lt;unique error id&gt;"
 	 * @param request
 	 * @param response
 	 * @return valgrind detail(s)

--- a/src/main/java/org/jenkinsci/plugins/valgrind/parser/ValgrindSaxParser.java
+++ b/src/main/java/org/jenkinsci/plugins/valgrind/parser/ValgrindSaxParser.java
@@ -8,6 +8,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
+
 import org.jenkinsci.plugins.valgrind.model.ValgrindAuxiliary;
 import org.jenkinsci.plugins.valgrind.model.ValgrindError;
 import org.jenkinsci.plugins.valgrind.model.ValgrindErrorKind;
@@ -329,7 +331,7 @@ public class ValgrindSaxParser implements Serializable
 			if ( data == null )
 				return;
 			
-			data.append(new String(ch,start,length));
+			data.append(escapeHtml4(new String(ch,start,length)));
 		}
 		
 		public ValgrindReport getReport()

--- a/src/main/java/org/jenkinsci/plugins/valgrind/parser/ValgrindSaxParser.java
+++ b/src/main/java/org/jenkinsci/plugins/valgrind/parser/ValgrindSaxParser.java
@@ -342,6 +342,9 @@ public class ValgrindSaxParser implements Serializable
 	{
 		SAXParserFactory factory = SAXParserFactory.newInstance();
 		factory.setNamespaceAware(true);
+		factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+		factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+		factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 		SAXParser saxParser = factory.newSAXParser();
 		
 		Handler handler = new Handler();

--- a/src/test/java/org/jenkinsci/plugins/valgrind/parser/ValgrindSaxParserTest.java
+++ b/src/test/java/org/jenkinsci/plugins/valgrind/parser/ValgrindSaxParserTest.java
@@ -175,7 +175,7 @@ public class ValgrindSaxParserTest
 
 		final String expectedSuppression =
         "{\n" +
-		"   <insert_a_suppression_name_here>\n" +
+		"   insert_a_suppression_name_here\n" +
 		"   Memcheck:Addr1\n" +
 		"   fun:memcpy@@GLIBC_2.14\n" +
 		"   fun:access_already_freed_memory_memcpy\n" +

--- a/src/test/resources/org/jenkinsci/plugins/valgrind/parser/aux-data.xml
+++ b/src/test/resources/org/jenkinsci/plugins/valgrind/parser/aux-data.xml
@@ -87,7 +87,7 @@
     <rawtext>
 <![CDATA[
 {
-   <insert_a_suppression_name_here>
+   insert_a_suppression_name_here
    Memcheck:Addr1
    fun:memcpy@@GLIBC_2.14
    fun:access_already_freed_memory_memcpy


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Apply recommended fixes from OWASP Cheat Sheets to attempt to fix XXE and XSS vulnerabilities in Valgrind Plugin. Disables external entities and escapes all content used in the reports for HTML using Apache Commons Text `escapeHtml4`.

Fixes [SECURITY-1829](https://www.jenkins.io/security/advisory/2020-09-01/#SECURITY-1829), [SECURITY-1830](https://www.jenkins.io/security/advisory/2020-09-01/#SECURITY-1830)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
